### PR TITLE
feat: add missing sushi-catcher game to game list

### DIFF
--- a/games/index.html
+++ b/games/index.html
@@ -103,6 +103,10 @@
                 <div class="game-title">スローライフ剣士</div>
                 <div class="game-id">slow-life-swordsman</div>
             </a>
+            <a href="sushi-catcher/" class="game-card">
+                <div class="game-title">回転寿司キャッチャー</div>
+                <div class="game-id">sushi-catcher</div>
+            </a>
             <a href="tsumami-challenge/" class="game-card">
                 <div class="game-title">つまみチャレンジ</div>
                 <div class="game-id">tsumami-challenge</div>


### PR DESCRIPTION
Added 回転寿司キャッチャー (sushi-catcher) to the games list.

The game existed in the games directory but was missing from the index page. This update:
- Adds the missing game to maintain completeness
- Preserves alphabetical ordering in the list

Fixes #30

Generated with [Claude Code](https://claude.ai/code)